### PR TITLE
Feature/591 copy facets to clipboard

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "editor.rulers": [72, 79, 120],
     "editor.wordWrap": "wordWrapColumn",
     "editor.wordWrapColumn": 120,
-    "editor.defaultFormatter": "ms-python.python"
+    "editor.defaultFormatter": "ms-python.black-formatter"
   },
   // Update as needed
   "python.pythonPath": "backend/venv/bin/python",

--- a/backend/metagrid/api_globus/tests/test_views.py
+++ b/backend/metagrid/api_globus/tests/test_views.py
@@ -7,7 +7,12 @@ from metagrid.api_globus.views import split_value, truncate_urls
 
 class TestGlobusViewSet(APITestCase):
     def test_truncate(self):
-        lst = [{"url": ["test_url:globus_value|Globus"], "data_node": "aims3.llnl.gov"}]
+        lst = [
+            {
+                "url": ["test_url:globus_value|Globus"],
+                "data_node": "aims3.llnl.gov",
+            }
+        ]
         results = []
         for value in truncate_urls(lst):
             results.append(value)

--- a/backend/metagrid/api_globus/views.py
+++ b/backend/metagrid/api_globus/views.py
@@ -6,7 +6,11 @@ import urllib.request
 from datetime import datetime, timedelta
 
 from django.conf import settings
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseServerError
+from django.http import (
+    HttpResponse,
+    HttpResponseBadRequest,
+    HttpResponseServerError,
+)
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from globus_sdk import AccessTokenAuthorizer, TransferClient, TransferData
@@ -14,16 +18,12 @@ from globus_sdk import AccessTokenAuthorizer, TransferClient, TransferData
 from metagrid.api_proxy.views import do_request
 
 ENDPOINT_MAP = {
-    "415a6320-e49c-11e5-9798-22000b9da45e" : "1889ea03-25ad-4f9f-8110-1ce8833a9d7e"
+    "415a6320-e49c-11e5-9798-22000b9da45e": "1889ea03-25ad-4f9f-8110-1ce8833a9d7e"
 }
 
-DATANODE_MAP = {
-    "aims3.llnl.gov" : "1889ea03-25ad-4f9f-8110-1ce8833a9d7e"
-}
+DATANODE_MAP = {"aims3.llnl.gov": "1889ea03-25ad-4f9f-8110-1ce8833a9d7e"}
 
-TEST_SHARDS_MAP = {
-    "esgf-fedtest.llnl.gov" : "esgf-node.llnl.gov"
-}
+TEST_SHARDS_MAP = {"esgf-fedtest.llnl.gov": "esgf-node.llnl.gov"}
 
 
 # reserved query keywords
@@ -137,7 +137,9 @@ def get_files(url_params):  # pragma: no cover
     use_distrib = True
 
     try:
-        hostname = urllib.parse.urlparse(query_url).hostname  # TODO need to populate the sharts based on the Solr URL
+        hostname = urllib.parse.urlparse(
+            query_url
+        ).hostname  # TODO need to populate the sharts based on the Solr URL
     except RuntimeError as e:
         return HttpResponseServerError(f"Malformed URL in search results {e}")
     if hostname in TEST_SHARDS_MAP:
@@ -347,7 +349,7 @@ def do_globus_transfer(request):  # pragma: no cover
         parts = file.split("/")
         if data_node in DATANODE_MAP:
             endpoint_id = DATANODE_MAP[data_node]
-            print("Data node mapping.....") 
+            print("Data node mapping.....")
         else:
             endpoint_id = parts[0]
             if endpoint_id in ENDPOINT_MAP:
@@ -365,7 +367,6 @@ def do_globus_transfer(request):  # pragma: no cover
     print()
 
     for source_endpoint, source_files in list(download_map.items()):
-
         # submit transfer request
         task_id = submit_transfer(
             transfer_client,

--- a/frontend/src/components/Facets/FacetsForm.test.tsx
+++ b/frontend/src/components/Facets/FacetsForm.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../api/mock/fixtures';
 import FacetsForm, { humanizeFacetNames, Props } from './FacetsForm';
 import { customRenderKeycloak } from '../../test/custom-render';
+import { printElementContents } from '../../test/jestTestFunctions';
 
 const user = userEvent.setup();
 
@@ -121,7 +122,7 @@ describe('test FacetsForm component', () => {
     expect(items).toEqual('aims3.llnl.gov\nesgf1.dkrz.de');
 
     // Expect result message to show
-    const resultNotification = getByText('Options copied to clipboard!');
+    const resultNotification = getByText('Data Nodes copied to clipboard!');
     expect(resultNotification).toBeTruthy();
     await user.click(resultNotification);
   });

--- a/frontend/src/components/Facets/FacetsForm.test.tsx
+++ b/frontend/src/components/Facets/FacetsForm.test.tsx
@@ -101,6 +101,31 @@ describe('test FacetsForm component', () => {
     await user.click(collapseAllBtn);
   });
 
+  it('handles copying facet items to clip board', async () => {
+    const { getByText, getByRole } = customRenderKeycloak(
+      <FacetsForm {...defaultProps} />
+    );
+
+    // Expand the group1 panel
+    const group1Btn = getByText('Group1');
+    expect(group1Btn).toBeTruthy();
+    await user.click(group1Btn);
+
+    // Click the copy facets button
+    const copyBtn = getByRole('img', { name: 'copy' });
+    expect(copyBtn).toBeTruthy();
+    await user.click(copyBtn);
+
+    // Check the clipboard has items
+    const items = await navigator.clipboard.readText();
+    expect(items).toEqual('aims3.llnl.gov\nesgf1.dkrz.de');
+
+    // Expect result message to show
+    const resultNotification = getByText('Options copied to clipboard!');
+    expect(resultNotification).toBeTruthy();
+    await user.click(resultNotification);
+  });
+
   it('handles changing expand to collapse and vice-versa base on user actions', async () => {
     const { getByText } = customRenderKeycloak(
       <FacetsForm {...defaultProps} />

--- a/frontend/src/components/Facets/FacetsForm.test.tsx
+++ b/frontend/src/components/Facets/FacetsForm.test.tsx
@@ -8,7 +8,6 @@ import {
 } from '../../api/mock/fixtures';
 import FacetsForm, { humanizeFacetNames, Props } from './FacetsForm';
 import { customRenderKeycloak } from '../../test/custom-render';
-import { printElementContents } from '../../test/jestTestFunctions';
 
 const user = userEvent.setup();
 

--- a/frontend/src/components/Facets/FacetsForm.tsx
+++ b/frontend/src/components/Facets/FacetsForm.tsx
@@ -348,6 +348,7 @@ const FacetsForm: React.FC<React.PropsWithChildren<Props>> = ({
                       const isOptionalforDatasets =
                         facetOptions.length > 0 &&
                         facetOptions[0].includes('none');
+                      const facetNameHumanized = humanizeFacetNames(facet);
                       return (
                         <Form.Item
                           key={facet}
@@ -360,9 +361,7 @@ const FacetsForm: React.FC<React.PropsWithChildren<Props>> = ({
                                 style={{ marginLeft: '5px' }}
                                 icon={
                                   <Tooltip
-                                    title={`Copy ${humanizeFacetNames(
-                                      facet
-                                    )}s to clipboard`}
+                                    title={`Copy ${facetNameHumanized}s to clipboard`}
                                   >
                                     <CopyOutlined
                                       style={{ fontSize: '12px' }}
@@ -380,13 +379,16 @@ const FacetsForm: React.FC<React.PropsWithChildren<Props>> = ({
                                         })
                                         .join('\n')
                                     );
-                                    showNotice('Options copied to clipboard!', {
-                                      icon: (
-                                        <CopyOutlined
-                                          style={styles.messageAddIcon}
-                                        />
-                                      ),
-                                    });
+                                    showNotice(
+                                      `${facetNameHumanized}s copied to clipboard!`,
+                                      {
+                                        icon: (
+                                          <CopyOutlined
+                                            style={styles.messageAddIcon}
+                                          />
+                                        ),
+                                      }
+                                    );
                                   }
                                 }}
                               ></Button>

--- a/frontend/src/components/Facets/FacetsForm.tsx
+++ b/frontend/src/components/Facets/FacetsForm.tsx
@@ -1,4 +1,5 @@
 import {
+  CopyOutlined,
   InfoCircleOutlined,
   RightCircleOutlined,
   SearchOutlined,
@@ -30,6 +31,7 @@ import {
 } from '../Search/types';
 import { ActiveFacets, ParsedFacets } from './types';
 import { globusEnabledNodes } from '../../env';
+import { showNotice } from '../../common/utils';
 
 const styles: CSSinJS = {
   container: {
@@ -351,10 +353,46 @@ const FacetsForm: React.FC<React.PropsWithChildren<Props>> = ({
                           key={facet}
                           name={facet}
                           label={
-                            humanizeFacetNames(facet) +
-                            (isOptionalforDatasets ? ' (Optional)' : '')
+                            <div>
+                              {humanizeFacetNames(facet)}
+                              <Button
+                                size="small"
+                                style={{ marginLeft: '5px' }}
+                                icon={
+                                  <Tooltip
+                                    title={`Copy ${humanizeFacetNames(
+                                      facet
+                                    )}s to clipboard`}
+                                  >
+                                    <CopyOutlined
+                                      style={{ fontSize: '12px' }}
+                                    />
+                                  </Tooltip>
+                                }
+                                onClick={() => {
+                                  // copy link to clipboard
+                                  /* istanbul ignore else */
+                                  if (navigator && navigator.clipboard) {
+                                    navigator.clipboard.writeText(
+                                      facetOptions
+                                        .map((item) => {
+                                          return item[0];
+                                        })
+                                        .join('\n')
+                                    );
+                                    showNotice('Options copied to clipboard!', {
+                                      icon: (
+                                        <CopyOutlined
+                                          style={styles.messageAddIcon}
+                                        />
+                                      ),
+                                    });
+                                  }
+                                }}
+                              ></Button>
+                            </div>
                           }
-                          style={{ marginBottom: '0px' }}
+                          style={{ marginBottom: 0 }}
                           tooltip={
                             isOptionalforDatasets
                               ? {


### PR DESCRIPTION
## Description

This adds a simple copy button in the facets bar, so users can copy a list of facets to their clipboard (per suggestion/feedback).

Fixes #591 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Local Pre-commit Checks
- [x] CI/CD Build

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] If applicable - I have commented my code, particularly in hard-to-understand areas
- [x] If applicable - I have made corresponding changes to the documentation
- [x] If applicable - I have added tests that prove my fix is effective or that my feature works
- [x] If applicable - New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
