### PR TITLE
Support custom Solr port

### DIFF
--- a/backend/metagrid/api_globus/views.py
+++ b/backend/metagrid/api_globus/views.py
@@ -151,7 +151,6 @@ def get_files(url_params):  # pragma: no cover
         return HttpResponseServerError(f"Malformed URL in search results {e}")
     if hostname in TEST_SHARDS_MAP:
         hostname = TEST_SHARDS_MAP[hostname]
-    
     xml_shards = [f"{hostname}:{port}/solr"]
     querys = []
     file_query = ["type:File"]

--- a/backend/metagrid/api_globus/views.py
+++ b/backend/metagrid/api_globus/views.py
@@ -138,15 +138,21 @@ def get_files(url_params):  # pragma: no cover
     file_offset = 0
     use_distrib = True
 
+    port = "80"
+
     try:
-        hostname = urllib.parse.urlparse(
+        res = urllib.parse.urlparse(
             query_url
-        ).hostname  # TODO need to populate the sharts based on the Solr URL
+        )
+        hostname = res.hostname  # TODO need to populate the shards based on the Solr URL
+        if res.port:
+            port = res.port
     except RuntimeError as e:
         return HttpResponseServerError(f"Malformed URL in search results {e}")
     if hostname in TEST_SHARDS_MAP:
         hostname = TEST_SHARDS_MAP[hostname]
-    xml_shards = [f"{hostname}:80/solr"]
+    
+    xml_shards = [f"{hostname}:{port}/solr"]
     querys = []
     file_query = ["type:File"]
 


### PR DESCRIPTION
Currently, the Solr port is hardcoded to 80.  This change supports custom ports.  
Note this will be difficult to test at LLNL, we request support from partner sites that benefit from the change