### PR TITLE
Add hash annotation to Deployments to ensure restart when config chan…

### DIFF
--- a/backend/config/settings/static.py
+++ b/backend/config/settings/static.py
@@ -270,8 +270,8 @@ class DjangoStaticSettings(BaseSettings):
     # https://docs.djangoproject.com/en/3.2/ref/settings/#login-url
     LOGIN_URL: str = "/login/globus/"
 
-    LOGIN_REDIRECT_URL: str = "http://localhost:9443/search"
-    LOGOUT_REDIRECT_URL: str = "http://localhost:9443/search"
+    LOGIN_REDIRECT_URL: str = "/search"
+    LOGOUT_REDIRECT_URL: str = "/search"
 
     SOCIAL_AUTH_GLOBUS_SCOPE: list[str] = [
         "openid",

--- a/helm/templates/backend/deployment.yaml
+++ b/helm/templates/backend/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: backend
     {{- include "metagrid.labels" . | nindent 4 }}
+    config.txt/hash: {{ include (print $.Template.BasePath "/backend/secret.yaml") . | sha256sum }}
 spec:
   {{- if not .Values.backend.autoscaling.enabled }}
   replicas: {{ .Values.backend.replicaCount }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -16,12 +16,12 @@ spec:
   {{- with .Values.ingress.className }}
   ingressClassName: {{ . }}
   {{- end }}
-  {{- if .Values.ingress.tls -}}
+  {{- if .Values.ingress.tls }}
   tls:
   - hosts:
     - {{ .Values.ingress.host | quote }}
     secretName: {{ include "metagrid.fullname" . }}-ingress-cert
-  {{- end}}
+  {{- end }}
   rules:
   - host: {{ .Values.ingress.host | quote }}
     http:

--- a/helm/templates/node_status/deployment.yaml
+++ b/helm/templates/node_status/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/component: node-status-backend
     {{- include "metagrid.labels" . | nindent 4 }}
+    config.txt/hash: {{ include (print $.Template.BasePath "/node_status/secret.yaml") . | sha256sum }}
+
 spec:
   {{- if not .Values.nodeStatusBackend.autoscaling.enabled }}
   replicas: {{ .Values.nodeStatusBackend.replicaCount }}


### PR DESCRIPTION
## Description

- Fixes typos in helm ingress template that cause issues with vanilla k8s TLS
- Adds hash of config files as annotations to Deployments to ensure pod restarts when config changes
- Set `LOGIN_REDIRECT_URL` and `LOGIN_REDIRECT_URL` to relative urls so they don't have to be manually set per site

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Local Pre-commit Checks
- [x] CI/CD Build

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] If applicable - I have commented my code, particularly in hard-to-understand areas
- [x] If applicable - I have made corresponding changes to the documentation
- [x] If applicable - I have added tests that prove my fix is effective or that my feature works
- [x] If applicable - New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
