### PR TITLE
Added error handling for failed fetch search results.

### DIFF
--- a/frontend/src/components/Cart/SearchesCard.tsx
+++ b/frontend/src/components/Cart/SearchesCard.tsx
@@ -135,13 +135,15 @@ const SearchesCard: React.FC<React.PropsWithChildren<Props>> = ({
               data-testid={`apply-${index + 1}`}
               key="search"
               onClick={() => {
-                navigate('/search');
                 // Set searchTime to 0 so that it'll be considered expired and updated
                 updateSearchQuery({
                   ...searchQuery,
                   searchTime: 0,
                 });
                 setSavedSearchQuery(searchQuery);
+
+                // Navigate to the search page with the query
+                navigate('/search');
               }}
             />
           </Tooltip>,

--- a/frontend/src/components/Facets/FacetsForm.tsx
+++ b/frontend/src/components/Facets/FacetsForm.tsx
@@ -32,7 +32,7 @@ import Button from '../General/Button';
 import StatusToolTip from '../NodeStatus/StatusToolTip';
 import { ActiveSearchQuery, ResultType, VersionType } from '../Search/types';
 import { ActiveFacets, ParsedFacets } from './types';
-import { showError, showNotice } from '../../common/utils';
+import { clearCachedSearchResults, showError, showNotice } from '../../common/utils';
 import { activeSearchQueryAtom, availableFacetsAtom } from '../../common/atoms';
 import { leftSidebarTargets } from '../../common/joyrideTutorials/reactJoyrideSteps';
 
@@ -412,6 +412,9 @@ const FacetsForm: React.FC = () => {
                             handleOnSelectAvailableFacetsForm(facet, value);
                           }}
                           options={facetOptions.map((variable) => {
+                            if (typeof variable[0] !== 'string') {
+                              clearCachedSearchResults();
+                            }
                             let optionOutput: string | React.ReactNode = (
                               <>
                                 {variable[0]}


### PR DESCRIPTION
If search fails and cached results are available it will use cached results and notify user there's a problem. Resets the pagination and current request URL. If issue occurs in rendering facets, (sometimes caused by old cache) we reset search cache. Cached results will still expire after an hour and therefore the fetch error will be shown if the fetching problems persist for long enough.

## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Fixes # (issue)

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [ ] Local Pre-commit Checks
- [ ] CI/CD Build

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] If applicable - I have commented my code, particularly in hard-to-understand areas
- [ ] If applicable - I have made corresponding changes to the documentation
- [ ] If applicable - I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable - New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
