### PR TITLE
Fixes disabling node status in the Helm chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -73,18 +73,21 @@ This document describes the configurable values available in the `values.yaml` f
 | `ingress.annotations` | Custom annotations for ingress resources.                         | `object` | `{}`    |
 
 ---
+## Features
 
+| Parameter                          | Description                                                                | Type        | Default |    
+|------------------------------------|----------------------------------------------------------------------------|-------------|---------|
+| `features.nodeStatus.enabled`      | Enables node status feature, deploying Prometheus and blackbox exporter.   | `boolean`   | `true`  |         
+| `features.nodeStatus.url`          | Overrides and disables the default Prometheus deployment.                  | `string`    | N/A     |  
+
+---
 ## Config
 
 | Parameter                                 | Description                                                                                      | Type     | Default                                         |
 |-------------------------------------------|--------------------------------------------------------------------------------------------------|----------|-------------------------------------------------|
-| `config.PGHOST`                           | PostgreSQL host value, dynamically set using the `postgresql-ha` subchart.                        | `string` | N/A                                             |
-| `config.PGUSER`                           | PostgreSQL username value, dynamically set using the `postgresql-ha` subchart.                    | `string` | N/A                                             |
-| `config.PGPASSWORD`                       | PostgreSQL password value, dynamically set using the `postgresql-ha` subchart.                    | `string` | N/A                                             |
 | `config.GUNICORN_WORKERS`                 | Number of Gunicorn workers for handling requests.                                                 | `string` | `'2'`                                           |
 | `config.METAGRID_SEARCH_URL`              | URL for the Metagrid search service.                                                              | `string` | `https://esgf-node.ornl.gov/esg-search/search`   |
 | `config.METAGRID_WGET_URL`                | URL for the Metagrid wget service.                                                                | `string` | `https://esgf-node.ornl.gov/esg-search/wget`    |
-| `config.METAGRID_STATUS_URL`              | URL for checking Metagrid status, dynamically referenced.                                         | `string` | N/A                                             |
 | `config.METAGRID_SOCIAL_AUTH_GLOBUS_KEY`  | Placeholder key for Globus authentication.                                                        | `string` | `"key"`                                        |
 | `config.METAGRID_SOCIAL_AUTH_GLOBUS_SECRET`| Placeholder secret for Globus authentication.                                                     | `string` | `"secret"`                                     |
 | `config.METAGRID_GLOBUS_CLIENT_ID`        | Client ID for Globus authentication.                                                              | `string` | `"clientID"`                                   |

--- a/helm/templates/backend/secret.yaml
+++ b/helm/templates/backend/secret.yaml
@@ -9,4 +9,8 @@ stringData:
   PGHOST: {{ include "postgresql-ha.pgpool" .Subcharts.postgresql }}
   PGUSER: {{ include "postgresql-ha.postgresqlUsername" .Subcharts.postgresql }}
   PGPASSWORD: {{ coalesce .Subcharts.postgresql.Values.postgresql.password .Subcharts.postgresql.Values.global.postgresql.password }}
+  {{- if .Values.features.nodeStatus.enabled }}
+  {{ $defaultNodeStatusUrl := printf "http://%s-node-status-backend:9090/api/v1/query?query=probe_success%7Bjob%3D%22http_2xx%22%2C+target%3D~%22.%2Athredds.%2A%22%7D" (include "metagrid.fullname" .) }}
+  METAGRID_STATUS_URL: {{ default $defaultNodeStatusUrl .Values.features.nodeStatus.url }}
+  {{- end }}
   {{- tpl (toYaml .Values.config) . | nindent 2 }}

--- a/helm/templates/node_status/deployment.yaml
+++ b/helm/templates/node_status/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.features.nodeStatus.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -113,3 +114,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -9,11 +9,15 @@ ingress:
   labels: {}
   annotations: {}
 
+features:
+  nodeStatus:
+    enabled: true
+    url:
+
 config:
   GUNICORN_WORKERS: '2'
   METAGRID_SEARCH_URL: https://esgf-node.ornl.gov/esg-search/search
   METAGRID_WGET_URL: https://esgf-node.ornl.gov/esg-search/wget
-  METAGRID_STATUS_URL: http://{{ include "metagrid.fullname" . }}-node-status-backend:9090/api/v1/query?query=probe_success%7Bjob%3D%22http_2xx%22%2C+target%3D~%22.%2Athredds.%2A%22%7D
   # TODO implement logic to require these when using globus only, for now adding placeholders
   METAGRID_SOCIAL_AUTH_GLOBUS_KEY: "key"
   METAGRID_SOCIAL_AUTH_GLOBUS_SECRET: "secret"


### PR DESCRIPTION
## Description
- Adds option to toggle nodeStatus from Helm chart, this will completely disable the prometheus/blackbox deployment

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Fixes # (issue)

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [ ] Local Pre-commit Checks
- [ ] CI/CD Build

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] If applicable - I have commented my code, particularly in hard-to-understand areas
- [ ] If applicable - I have made corresponding changes to the documentation
- [ ] If applicable - I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable - New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
