### PR TITLE
#938 Apply msw v1 to v2 conversions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,7 +91,7 @@
     "globals": "17.5.0",
     "jsdom": "^27.4.0",
     "mock-match-media": "^0.4.3",
-    "msw": "1.3.5",
+    "msw": "2.13.5",
     "postcss": "8.5.9",
     "prettier": "3.8.3",
     "typescript-eslint": "8.58.2",

--- a/frontend/src/api/index.test.ts
+++ b/frontend/src/api/index.test.ts
@@ -47,7 +47,8 @@ import {
   userSearchQueriesFixture,
   userSearchQueryFixture,
 } from '../test/mock/fixtures';
-import { rest, server } from '../test/mock/server';
+import { http, server } from '../test/mock/server';
+import { HttpResponse } from 'msw';
 import apiRoutes, { HTTPCodeType } from './routes';
 
 const genericNetworkErrorMsg = 'Failed to Connect';
@@ -71,13 +72,21 @@ describe('test fetching user authentication with globus', () => {
     const userAuth = await fetchGlobusAuth();
     expect(userAuth).toEqual(userAuthFixture());
   });
+
   it('catches and throws error based on HTTP status code', async () => {
-    server.use(rest.get(apiRoutes.globusAuth.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.get(apiRoutes.globusAuth.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(fetchGlobusAuth()).rejects.toThrow(apiRoutes.globusAuth.handleErrorMsg(404));
   });
+
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.get(apiRoutes.globusAuth.path, (_req, res) => res.networkError(genericNetworkErrorMsg)),
+      http.get(apiRoutes.globusAuth.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(fetchGlobusAuth()).rejects.toThrow(apiRoutes.globusAuth.handleErrorMsg('generic'));
   });
@@ -88,17 +97,23 @@ describe('test fetching user authentication with keycloak', () => {
     const userAuth = await fetchUserAuth(['keycloak_token']);
     expect(userAuth).toEqual(userAuthFixture());
   });
+
   it('catches and throws error based on HTTP status code', async () => {
-    server.use(rest.post(apiRoutes.keycloakAuth.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.post(apiRoutes.keycloakAuth.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(fetchUserAuth(['keycloak_token'])).rejects.toThrow(
       apiRoutes.keycloakAuth.handleErrorMsg(404),
     );
   });
+
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.post(apiRoutes.keycloakAuth.path, (_req, res) =>
-        res.networkError(genericNetworkErrorMsg),
-      ),
+      http.post(apiRoutes.keycloakAuth.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(fetchUserAuth(['keycloak_token'])).rejects.toThrow(
       apiRoutes.keycloakAuth.handleErrorMsg('generic'),
@@ -113,14 +128,21 @@ describe('test fetching user info', () => {
   });
 
   it('returns error', async () => {
-    server.use(rest.get(apiRoutes.userInfo.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.get(apiRoutes.userInfo.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(fetchUserInfo(['access_token'])).rejects.toThrow(
       apiRoutes.userInfo.handleErrorMsg(404),
     );
   });
+
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.get(apiRoutes.userInfo.path, (_req, res) => res.networkError(genericNetworkErrorMsg)),
+      http.get(apiRoutes.userInfo.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(fetchUserInfo(['access_token'])).rejects.toThrow(
       apiRoutes.userInfo.handleErrorMsg('generic'),
@@ -156,18 +178,23 @@ describe('test fetching projects', () => {
     // Set STAC URL to empty string to not include STAC projects
     mockConfig.STAC_URL = null;
     const projects = (await fetchProjects()).results;
-
     expect(projects).toEqual([...projectsFixture()]);
   });
 
   it('catches and throws an error based on HTTP status code', async () => {
-    server.use(rest.get(apiRoutes.projects.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.get(apiRoutes.projects.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(fetchProjects()).rejects.toThrow(apiRoutes.projects.handleErrorMsg(404));
   });
 
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.get(apiRoutes.projects.path, (_req, res) => res.networkError(genericNetworkErrorMsg)),
+      http.get(apiRoutes.projects.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(fetchProjects()).rejects.toThrow(apiRoutes.projects.handleErrorMsg('generic'));
   });
@@ -178,9 +205,9 @@ describe('test fetching projects', () => {
 
     // Mock the projects endpoint to return an object without `results`
     server.use(
-      rest.get(apiRoutes.projects.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ count: 0 })),
-      ),
+      http.get(apiRoutes.projects.path, () => {
+        return HttpResponse.json({ count: 0 });
+      }),
     );
 
     const projects = (await fetchProjects()).results;
@@ -225,17 +252,14 @@ describe('test fetching projects', () => {
 
     // Mock backend to include a legacy CMIP6 project
     server.use(
-      rest.get(apiRoutes.projects.path, (_req, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json({
-            results: [
-              ...projectsFixture(),
-              { pk: '4', name: 'CMIP6', fullName: 'CMIP6 Legacy', isSTAC: false },
-            ],
-          }),
-        ),
-      ),
+      http.get(apiRoutes.projects.path, () => {
+        return HttpResponse.json({
+          results: [
+            ...projectsFixture(),
+            { pk: '4', name: 'CMIP6', fullName: 'CMIP6 Legacy', isSTAC: false },
+          ],
+        });
+      }),
     );
 
     // No blacklist - both CMIP6 and CMIP6 STAC should be present
@@ -403,7 +427,9 @@ describe('test fetching search results', () => {
 
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.get(apiRoutes.esgfSearch.path, (_req, res) => res.networkError(genericNetworkErrorMsg)),
+      http.get(apiRoutes.esgfSearch.path), () => {
+        return HttpResponse.error();
+      })
     );
     await expect(fetchSearchResults([reqUrl])).rejects.toThrow(
       apiRoutes.esgfSearch.handleErrorMsg('generic'),
@@ -411,8 +437,11 @@ describe('test fetching search results', () => {
   });
 
   it('throws a user-friendly error when status is 422', async () => {
-    server.use(rest.get(apiRoutes.esgfSearch.path, (_req, res, ctx) => res(ctx.status(422))));
-
+    server.use(
+      http.get(apiRoutes.esgfSearch.path, () => {
+        return new HttpResponse(null, { status: 422 });
+      })
+    );
     reqUrl += '?offset=9999&limit=10&latest=true';
     await expect(fetchSearchResults([reqUrl])).rejects.toThrow(
       apiRoutes.esgfSearch.handleErrorMsg('generic'),
@@ -482,13 +511,18 @@ describe('test fetching citation', () => {
     expect(newCitation).toEqual(results);
   });
   it('catches and throws an error based on HTTP status code', async () => {
-    server.use(rest.post(apiRoutes.citation.path, (_req, res, ctx) => res(ctx.status(404))));
-
+    server.use(
+      http.get(apiRoutes.citation.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(fetchDatasetCitation({})).rejects.toThrow(apiRoutes.citation.handleErrorMsg(404));
   });
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.post(apiRoutes.citation.path, (_req, res) => res.networkError(genericNetworkErrorMsg)),
+      http.get(apiRoutes.citation.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(fetchDatasetCitation({})).rejects.toThrow(
       apiRoutes.citation.handleErrorMsg('generic'),
@@ -515,7 +549,11 @@ describe('test fetchFiles()', () => {
     expect(files).toEqual(ESGFSearchAPIFixture());
   });
   it('catches and throws an error based on HTTP status code', async () => {
-    server.use(rest.get(apiRoutes.esgfSearch.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.get(apiRoutes.esgfSearch.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(fetchDatasetFiles([], props)).rejects.toThrow(
       apiRoutes.esgfSearch.handleErrorMsg(404),
     );
@@ -523,7 +561,9 @@ describe('test fetchFiles()', () => {
 
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.get(apiRoutes.esgfSearch.path, (_req, res) => res.networkError(genericNetworkErrorMsg)),
+      http.get(apiRoutes.esgfSearch.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(fetchDatasetFiles([], props)).rejects.toThrow(
       apiRoutes.esgfSearch.handleErrorMsg('generic'),
@@ -537,14 +577,20 @@ describe('test fetching user cart', () => {
     expect(files).toEqual(rawUserCartFixture());
   });
   it('catches and throws an error based on HTTP status code', async () => {
-    server.use(rest.get(apiRoutes.userCart.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.get(apiRoutes.userCart.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(fetchUserCart('pk', 'access_token')).rejects.toThrow(
       apiRoutes.userCart.handleErrorMsg(404),
     );
   });
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.get(apiRoutes.userCart.path, (_req, res) => res.networkError(genericNetworkErrorMsg)),
+      http.get(apiRoutes.userCart.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(fetchUserCart('pk', 'access_token')).rejects.toThrow(
       apiRoutes.userCart.handleErrorMsg('generic'),
@@ -566,14 +612,20 @@ describe('test updating user cart', () => {
     expect(again).toEqual(rawUserCartFixture());
   });
   it('catches and throws an error based on HTTP status code', async () => {
-    server.use(rest.patch(apiRoutes.userCart.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.patch(apiRoutes.userCart.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(updateUserCart('pk', 'access_token', [])).rejects.toThrow(
       apiRoutes.userCart.handleErrorMsg(404),
     );
   });
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.patch(apiRoutes.userCart.path, (_req, res) => res.networkError(genericNetworkErrorMsg)),
+      http.patch(apiRoutes.userCart.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(updateUserCart('pk', 'access_token', [])).rejects.toThrow(
       apiRoutes.userCart.handleErrorMsg('generic'),
@@ -588,17 +640,20 @@ describe('test fetching user searches', () => {
     expect(res).toEqual({ results: userSearchQueriesFixture() });
   });
   it('catches and throws an error based on HTTP status code', async () => {
-    server.use(rest.get(apiRoutes.userSearches.path, (_req, res, ctx) => res(ctx.status(404))));
-
+    server.use(
+      http.get(apiRoutes.userSearches.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(fetchUserSearchQueries('access_token')).rejects.toThrow(
       apiRoutes.userSearches.handleErrorMsg(404),
     );
   });
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.get(apiRoutes.userSearches.path, (_req, res) =>
-        res.networkError(genericNetworkErrorMsg),
-      ),
+      http.get(apiRoutes.userSearches.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(fetchUserSearchQueries('access_token')).rejects.toThrow(
       apiRoutes.userSearches.handleErrorMsg('generic'),
@@ -614,8 +669,11 @@ describe('test adding user search', () => {
     expect(res).toEqual(payload);
   });
   it('catches and throws an error based on HTTP status code', async () => {
-    server.use(rest.post(apiRoutes.userSearches.path, (_req, res, ctx) => res(ctx.status(404))));
-
+    server.use(
+      http.post(apiRoutes.userSearches.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     const payload = userSearchQueryFixture();
     await expect(addUserSearchQuery('pk', 'access_token', payload)).rejects.toThrow(
       apiRoutes.userSearches.handleErrorMsg(404),
@@ -624,11 +682,10 @@ describe('test adding user search', () => {
 
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.post(apiRoutes.userSearches.path, (_req, res) =>
-        res.networkError(genericNetworkErrorMsg),
-      ),
+      http.post(apiRoutes.userSearches.path, () => {
+        return HttpResponse.error();
+      })
     );
-
     const payload = userSearchQueryFixture();
     await expect(addUserSearchQuery('pk', 'access_token', payload)).rejects.toThrow(
       apiRoutes.userSearches.handleErrorMsg('generic'),
@@ -643,19 +700,21 @@ describe('test deleting user search', () => {
     expect(res).toEqual('');
   });
   it('catches and throws an error based on HTTP status code', async () => {
-    server.use(rest.delete(apiRoutes.userSearch.path, (_req, res, ctx) => res(ctx.status(404))));
-
+    server.use(
+      http.delete(apiRoutes.userSearch.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(deleteUserSearchQuery('pk', 'access_token')).rejects.toThrow(
       apiRoutes.userSearch.handleErrorMsg(404),
     );
   });
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.delete(apiRoutes.userSearch.path, (_req, res) =>
-        res.networkError(genericNetworkErrorMsg),
-      ),
+      http.delete(apiRoutes.userSearch.path, () => {
+        return HttpResponse.error();
+      })
     );
-
     await expect(deleteUserSearchQuery('pk', 'access_token')).rejects.toThrow(
       apiRoutes.userSearch.handleErrorMsg('generic'),
     );
@@ -671,13 +730,18 @@ describe('test fetching wget script', () => {
   });
 
   it('catches and throws an error based on HTTP status code', async () => {
-    server.use(rest.post(apiRoutes.wget.path, (_req, res, ctx) => res(ctx.status(404))));
-
+    server.use(
+      http.post(apiRoutes.wget.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(fetchWgetScript(['id'])).rejects.toThrow(apiRoutes.wget.handleErrorMsg(404));
   });
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.post(apiRoutes.wget.path, (_req, res) => res.networkError(genericNetworkErrorMsg)),
+      http.post(apiRoutes.wget.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(fetchWgetScript(['id'])).rejects.toThrow(apiRoutes.wget.handleErrorMsg('generic'));
   });
@@ -734,9 +798,10 @@ describe('test user endpoint search', () => {
   });
   it('throws 404 error', async () => {
     server.use(
-      rest.get(apiRoutes.globusSearchEndpoints.path, (_req, res, ctx) => res(ctx.status(404))),
+      http.get(apiRoutes.globusSearchEndpoints.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
     );
-
     await expect(startSearchGlobusEndpoints('lc public')).rejects.toThrow(
       apiRoutes.globusSearchEndpoints.handleErrorMsg(404),
     );
@@ -759,9 +824,10 @@ describe('test fetching node status', () => {
 
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.get(apiRoutes.nodeStatus.path, (_req, res) => res.networkError(genericNetworkErrorMsg)),
+      http.get(apiRoutes.nodeStatus.path, () => {
+        return HttpResponse.error();
+      })
     );
-
     await expect(fetchNodeStatus()).rejects.toThrow(apiRoutes.nodeStatus.handleErrorMsg('generic'));
   });
 });
@@ -809,11 +875,19 @@ describe('testing session storage', () => {
     expect(loadRes).toEqual(null);
   });
   it('Testing a bad response is received for load', () => {
-    server.use(rest.post(apiRoutes.tempStorageGet.path, (_req, res, ctx) => res(ctx.status(400))));
+    server.use(
+      http.post(apiRoutes.tempStorageGet.path, () => {
+        return new HttpResponse(null, { status: 400 });
+      })
+    );
     expect(loadSessionValue('test')).rejects.toThrow(apiRoutes.tempStorageGet.handleErrorMsg(400));
   });
   it('Testing a bad response is received for save', () => {
-    server.use(rest.post(apiRoutes.tempStorageSet.path, (_req, res, ctx) => res(ctx.status(400))));
+    server.use(
+      http.post(apiRoutes.tempStorageSet.path, () => {
+        return new HttpResponse(null, { status: 400 });
+      })
+    );
     expect(saveSessionValue('test', 'value')).rejects.toThrow(
       apiRoutes.tempStorageSet.handleErrorMsg(400),
     );
@@ -1023,7 +1097,11 @@ describe('test fetching temp storage get', () => {
   });
 
   it('catches and throws an error based on HTTP status code', async () => {
-    server.use(rest.post(apiRoutes.tempStorageGet.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.post(apiRoutes.tempStorageGet.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(loadSessionValue('testKey')).rejects.toThrow(
       apiRoutes.tempStorageGet.handleErrorMsg(404),
     );
@@ -1031,9 +1109,9 @@ describe('test fetching temp storage get', () => {
 
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.post(apiRoutes.tempStorageGet.path, (_req, res) =>
-        res.networkError(genericNetworkErrorMsg),
-      ),
+      http.post(apiRoutes.tempStorageGet.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(loadSessionValue('testKey')).rejects.toThrow(
       apiRoutes.tempStorageGet.handleErrorMsg('generic'),
@@ -1048,7 +1126,11 @@ describe('test fetching temp storage set', () => {
   });
 
   it('catches and throws an error based on HTTP status code', async () => {
-    server.use(rest.post(apiRoutes.tempStorageSet.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.post(apiRoutes.tempStorageSet.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
     await expect(saveSessionValue('testKey', 'testValue')).rejects.toThrow(
       apiRoutes.tempStorageSet.handleErrorMsg(404),
     );
@@ -1056,9 +1138,9 @@ describe('test fetching temp storage set', () => {
 
   it('catches and throws generic network error', async () => {
     server.use(
-      rest.post(apiRoutes.tempStorageSet.path, (_req, res) =>
-        res.networkError(genericNetworkErrorMsg),
-      ),
+      http.post(apiRoutes.tempStorageSet.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(saveSessionValue('testKey', 'testValue')).rejects.toThrow(
       apiRoutes.tempStorageSet.handleErrorMsg('generic'),
@@ -1074,9 +1156,9 @@ describe('resetGlobusTokens', () => {
 
   it('throws an error when request fails', async () => {
     server.use(
-      rest.get(apiRoutes.globusResetTokens.path, (_req, res) =>
-        res.networkError(genericNetworkErrorMsg),
-      ),
+      http.get(apiRoutes.globusResetTokens.path, () => {
+        return HttpResponse.error();
+      })
     );
     await expect(resetGlobusTokens()).rejects.toThrow();
   });
@@ -1106,13 +1188,13 @@ describe('STAC API functions', () => {
     let capturedSearchBody: { collections: string[]; filter: unknown } | null = null;
 
     server.use(
-      rest.post(apiRoutes.esgfAggregationsSTAC.path, async (req, res, ctx) => {
-        capturedAggBody = await req.json();
-        return res(ctx.status(200), ctx.json(aggregationsResp));
+      http.post(apiRoutes.esgfAggregationsSTAC.path, async ({ request }) => {
+        capturedAggBody = await request.json();
+        return HttpResponse.json(aggregationsResp);
       }),
-      rest.post(apiRoutes.esgfSearchSTAC.path, async (req, res, ctx) => {
-        capturedSearchBody = await req.json();
-        return res(ctx.status(200), ctx.json(stacSearchResp));
+      http.post(apiRoutes.esgfSearchSTAC.path, async ({ request }) => {
+        capturedSearchBody = await request.json();
+        return HttpResponse.json(stacSearchResp);
       }),
     );
 
@@ -1137,10 +1219,12 @@ describe('STAC API functions', () => {
   it('returns stac result with empty facets when aggregations endpoint errors (status set accordingly)', async () => {
     // make aggregations endpoint return 500, search returns an empty feature collection
     server.use(
-      rest.post(apiRoutes.esgfAggregationsSTAC.path, (_req, res, ctx) => res(ctx.status(500))),
-      rest.post(apiRoutes.esgfSearchSTAC.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ type: 'FeatureCollection', features: [] })),
-      ),
+      http.post(apiRoutes.esgfAggregationsSTAC.path, () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+      http.post(apiRoutes.esgfSearchSTAC.path, () => {
+        return HttpResponse.json({ type: 'FeatureCollection', features: [] });
+      }),
     );
 
     const reqUrl = `${apiRoutes.esgfSearchSTAC.path}?project_id=CMIP6`;
@@ -1155,25 +1239,32 @@ describe('STAC API functions', () => {
 
   it('throws error when STAC aggregations fails', async () => {
     server.use(
-      rest.post(apiRoutes.esgfAggregationsSTAC.path, (_req, res, ctx) => res(ctx.status(500))),
+      http.post(apiRoutes.esgfAggregationsSTAC.path, () => {
+        return new HttpResponse(null, { status: 500 });
+      })
     );
-
     await expect(fetchSTACAggregations('CMIP6', 'test-url', undefined)).rejects.toThrow(
       apiRoutes.esgfAggregationsSTAC.handleErrorMsg('generic' as HTTPCodeType),
     );
   });
 
   it('throws error when STAC search fails', async () => {
-    server.use(rest.post(apiRoutes.esgfSearchSTAC.path, (_req, res, ctx) => res(ctx.status(500))));
-
+    server.use(
+      http.post(apiRoutes.esgfSearchSTAC.path, () => {
+        return new HttpResponse(null, { status: 500 });
+      })
+    );
     await expect(postSTACSearch('CMIP6', 10, undefined, undefined, undefined)).rejects.toThrow(
       apiRoutes.esgfSearchSTAC.handleErrorMsg('generic' as HTTPCodeType),
     );
   });
 
   it('throws error when STAC search endpoint fails', async () => {
-    server.use(rest.post(apiRoutes.esgfSearchSTAC.path, (_req, res, ctx) => res(ctx.status(500))));
-
+    server.use(
+      http.post(apiRoutes.esgfSearchSTAC.path, () => {
+        return new HttpResponse(null, { status: 500 });
+      })
+    );
     const reqUrl = `${apiRoutes.esgfSearchSTAC.path}?project_id=CMIP6`;
     await expect(fetchSearchResults({ reqUrl })).rejects.toThrow(
       apiRoutes.esgfSearchSTAC.handleErrorMsg('generic' as HTTPCodeType),

--- a/frontend/src/components/App/App.test.tsx
+++ b/frontend/src/components/App/App.test.tsx
@@ -9,7 +9,8 @@ import { fireEvent, within, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
-import { rest, server } from '../../test/mock/server';
+import { http, server } from '../../test/mock/server';
+import { HttpResponse } from 'msw';
 import apiRoutes from '../../api/routes';
 import { getSearchFromUrl } from '../../common/utils';
 import customRender from '../../test/custom-render';
@@ -522,8 +523,12 @@ describe('User cart', () => {
 describe('Error handling', () => {
   it('displays error message after failing to fetch authenticated user"s cart', async () => {
     server.use(
-      rest.get(apiRoutes.userCart.path, (_req, res, ctx) => res(ctx.status(404))),
-      rest.post(apiRoutes.userCart.path, (_req, res, ctx) => res(ctx.status(404))),
+      http.get(apiRoutes.userCart.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+      http.post(apiRoutes.userCart.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
     );
 
     customRender(<App searchQuery={activeSearch} />, {
@@ -746,8 +751,11 @@ describe('User search library', () => {
 
   describe('Error handling', () => {
     it('displays error message after failing to fetch authenticated user"s saved search queries', async () => {
-      server.use(rest.get(apiRoutes.userSearches.path, (_req, res, ctx) => res(ctx.status(404))));
-
+      server.use(
+        http.get(apiRoutes.userSearches.path, () => {
+          return new HttpResponse(null, { status: 404 });
+        })
+      );
       customRender(<App searchQuery={activeSearch} />);
 
       // Check applicable components render
@@ -767,7 +775,11 @@ describe('User search library', () => {
         },
       });
 
-      server.use(rest.post(apiRoutes.userSearches.path, (_req, res, ctx) => res(ctx.status(404))));
+      server.use(
+        http.post(apiRoutes.userSearches.path, () => {
+          return new HttpResponse(null, { status: 404 });
+        })
+      );
 
       // Wait for components to rerender
       await screen.findByTestId('main-query-string-label');
@@ -781,7 +793,11 @@ describe('User search library', () => {
 
     it('displays error message after failing to remove authenticated user"s saved search', async () => {
       // Override API response with 404
-      server.use(rest.delete(apiRoutes.userSearch.path, (_req, res, ctx) => res(ctx.status(404))));
+      server.use(
+        http.delete(apiRoutes.userSearch.path, () => {
+          return new HttpResponse(null, { status: 404 });
+        })
+      );
 
       customRender(<App searchQuery={activeSearch} />, {
         usesAtoms: true,

--- a/frontend/src/components/Cart/Items.test.tsx
+++ b/frontend/src/components/Cart/Items.test.tsx
@@ -2,7 +2,8 @@ import { within, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { rest, server } from '../../test/mock/server';
+import { http, server } from '../../test/mock/server';
+import { HttpResponse } from 'msw';
 import apiRoutes from '../../api/routes';
 import customRender from '../../test/custom-render';
 import Items, { Props } from './Items';
@@ -107,7 +108,11 @@ describe('test the cart items component', () => {
 
   it('handles error selecting items in the cart and downloading them via wget', async () => {
     // Override route HTTP response
-    server.use(rest.post(apiRoutes.wget.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.post(apiRoutes.wget.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
 
     customRender(<Items {...defaultProps} />);
 

--- a/frontend/src/components/Cart/SearchesCard.test.tsx
+++ b/frontend/src/components/Cart/SearchesCard.test.tsx
@@ -7,7 +7,8 @@ import {
   stacSearchResultsFixture,
   stacAggregationsFixture,
 } from '../../test/mock/fixtures';
-import { rest, server } from '../../test/mock/server';
+import { http, server } from '../../test/mock/server';
+import { HttpResponse } from 'msw';
 import apiRoutes from '../../api/routes';
 import SearchesCard, { Props } from './SearchesCard';
 import customRender from '../../test/custom-render';
@@ -56,7 +57,11 @@ it('renders components', async () => {
 });
 
 it('displays alert error when api fails to return response', async () => {
-  server.use(rest.get(apiRoutes.esgfSearch.path, (_req, res, ctx) => res(ctx.status(404))));
+  server.use(
+    http.get(apiRoutes.esgfSearch.path, () => {
+      return new HttpResponse(null, { status: 404 });
+    })
+  );
 
   customRender(
     <SearchesCard
@@ -86,12 +91,12 @@ it('displays "N/A" for Filename Searches when none are applied', async () => {
 it('updates searchQuery with STAC numMatched when project is STAC', async () => {
   // Mock STAC aggregations and STAC search responses
   server.use(
-    rest.post(apiRoutes.esgfAggregationsSTAC.path, (_req, res, ctx) =>
-      res(ctx.status(200), ctx.json(stacAggregationsFixture())),
-    ),
-    rest.post(apiRoutes.esgfSearchSTAC.path, (_req, res, ctx) =>
-      res(ctx.status(200), ctx.json(stacSearchResultsFixture().search)),
-    ),
+    http.post(apiRoutes.esgfAggregationsSTAC.path, () => {
+      return HttpResponse.json(stacAggregationsFixture());
+    })
+    http.post(apiRoutes.esgfSearchSTAC.path, () => {
+      return HttpResponse.json(stacSearchResultsFixture().search);
+    })
   );
 
   const mockUpdate = vi.fn();

--- a/frontend/src/components/Downloads/DatasetDownload.test.tsx
+++ b/frontend/src/components/Downloads/DatasetDownload.test.tsx
@@ -3,7 +3,8 @@ import userEvent from '@testing-library/user-event';
 import { within, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import customRender from '../../test/custom-render';
-import { rest, server } from '../../test/mock/server';
+import { http, server } from '../../test/mock/server';
+import { HttpResponse } from 'msw';
 import { getSearchFromUrl } from '../../common/utils';
 import { ActiveSearchQuery, StacSearchResponse } from '../Search/types';
 import {
@@ -260,7 +261,11 @@ describe('DatasetDownload form tests', () => {
 
   it('displays an error when wget script fails to fetch', async () => {
     await initializeComponentForTest();
-    server.use(rest.post(apiRoutes.wget.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.post(apiRoutes.wget.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
 
     // Open download dropdown
     const globusTransferDropdown = await within(
@@ -453,7 +458,11 @@ describe('DatasetDownload form tests', () => {
   });
 
   it('displays an error when Globus Transfer submission fails to reach backend', async () => {
-    server.use(rest.post(apiRoutes.globusTransfer.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.post(apiRoutes.globusTransfer.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
 
     await initializeComponentForTest();
 
@@ -468,14 +477,13 @@ describe('DatasetDownload form tests', () => {
 
   it('displays an error when one or more Globus Transfer submissions fail', async () => {
     server.use(
-      rest.post(apiRoutes.globusTransfer.path, (_req, res, ctx) =>
-        res(
-          ctx.status(207),
-          ctx.json({ status: 207, successes: [], failures: ['transfer failed'] }),
-        ),
-      ),
+      http.post(apiRoutes.globusTransfer.path, () => {
+        return HttpResponse.json(
+          { status: 207, successes: [], failures: ['transfer failed'] },
+          { status: 207 }
+        );
+      }),
     );
-
     await initializeComponentForTest();
 
     // Click Transfer button
@@ -485,6 +493,7 @@ describe('DatasetDownload form tests', () => {
 
     const globusTransferPopup = await screen.findByTestId('207-globus-failures-msg');
     expect(globusTransferPopup).toBeTruthy();
+  });
 
     // wait for endDownloadSteps to complete: transfer goal should be set to none
     await waitFor(
@@ -502,10 +511,10 @@ describe('DatasetDownload form tests', () => {
     let requestReceived = false;
 
     server.use(
-      rest.post(apiRoutes.globusTransfer.path, async (req, res, ctx) => {
+      http.post(apiRoutes.globusTransfer.path, async ({ request }) => {
         requestReceived = true;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const body = (await req.json()) as any;
+        const body = (await request.json()) as any;
 
         // Simulate a request with empty arrays (Bug #2 scenario)
         // Override whatever the component sends
@@ -518,17 +527,14 @@ describe('DatasetDownload form tests', () => {
           (body.globus_hrefs && body.globus_hrefs.length > 0);
 
         if (!hasData) {
-          return res(
-            ctx.status(200),
-            ctx.json({
-              status: 200,
-              successes: [],
-              failures: [],
-            }),
-          );
+          return HttpResponse.json({
+            status: 200,
+            successes: [],
+            failures: [],
+          });
         }
 
-        return res(ctx.status(200), ctx.json(globusTransferResponseFixture()));
+        return HttpResponse.json(globusTransferResponseFixture());
       }),
     );
 
@@ -555,14 +561,14 @@ describe('DatasetDownload form tests', () => {
 
     // Capture the request body
     server.use(
-      rest.post(apiRoutes.globusTransfer.path, async (req, res, ctx) => {
-        requestBody = (await req.json()) as {
+      http.post(apiRoutes.globusTransfer.path, async ({ request }) => {
+        requestBody = (await request.json()) as {
           dataset_id?: string[];
           globus_hrefs?: string[];
           endpointId?: string;
           path?: string;
         };
-        return res(ctx.status(200), ctx.json(globusTransferResponseFixture()));
+        return HttpResponse.json(globusTransferResponseFixture());
       }),
     );
 
@@ -598,15 +604,16 @@ describe('DatasetDownload form tests', () => {
     } | null = null;
 
     // Capture the request body
+
     server.use(
-      rest.post(apiRoutes.globusTransfer.path, async (req, res, ctx) => {
-        requestBody = (await req.json()) as {
+      http.post(apiRoutes.globusTransfer.path, async ({ request }) => {
+        requestBody = (await request.json()) as {
           dataset_id?: string[];
           globus_hrefs?: string[];
           endpointId?: string;
           path?: string;
         };
-        return res(ctx.status(200), ctx.json(globusTransferResponseFixture()));
+        return HttpResponse.json(globusTransferResponseFixture());
       }),
     );
 
@@ -637,19 +644,13 @@ describe('DatasetDownload form tests', () => {
 
   it('prompts user for consents if there is no auth code and transfer was denied due to permissions, then redirects to auth url when clicking OK', async () => {
     server.use(
-      rest.post(apiRoutes.globusTransfer.path, (_req, res, ctx) =>
-        res(
-          ctx.status(207),
-          ctx.json({
-            status: 207,
-            successes: [],
-            failures: ['permission denied'],
-            auth_url: 'http://test.globus.org/auth',
-          }),
-        ),
-      ),
+      http.post(apiRoutes.globusTransfer.path, () => {
+        return HttpResponse.json(
+          { status: 207, successes: [], failures: ['permission denied'], auth_url: 'http://test.globus.org/auth' },
+          { status: 207 }
+        );
+      }),
     );
-
     await initializeComponentForTest({
       ...defaultTestConfig,
       globusGoals: GlobusGoals.DoGlobusTransfer,
@@ -683,19 +684,13 @@ describe('DatasetDownload form tests', () => {
 
   it('prompts user for consents if there is no auth code and transfer was denied due to permissions, then cancels', async () => {
     server.use(
-      rest.post(apiRoutes.globusTransfer.path, (_req, res, ctx) =>
-        res(
-          ctx.status(207),
-          ctx.json({
-            status: 207,
-            successes: [],
-            failures: ['permission denied'],
-            auth_url: 'http://test.globus.org/auth',
-          }),
-        ),
-      ),
+      http.post(apiRoutes.globusTransfer.path, () => {
+        return HttpResponse.json(
+          { status: 207, successes: [], failures: ['permission denied'], auth_url: 'http://test.globus.org/auth' },
+          { status: 207 }
+        );
+      }),
     );
-
     await initializeComponentForTest({
       ...defaultTestConfig,
       globusGoals: GlobusGoals.DoGlobusTransfer,
@@ -726,19 +721,13 @@ describe('DatasetDownload form tests', () => {
 
   it('provides error message when permission was denied after receiving auth code', async () => {
     server.use(
-      rest.post(apiRoutes.globusTransfer.path, (_req, res, ctx) =>
-        res(
-          ctx.status(207),
-          ctx.json({
-            status: 207,
-            successes: [],
-            failures: ['permission denied'],
-            auth_url: 'http://test.globus.org/auth',
-          }),
-        ),
-      ),
+      http.post(apiRoutes.globusTransfer.path, () => {
+        return HttpResponse.json(
+          { status: 207, successes: [], failures: ['permission denied'], auth_url: 'http://test.globus.org/auth' },
+          { status: 207 }
+        );
+      }),
     );
-
     await initializeComponentForTest({
       ...defaultTestConfig,
       testUrlState: { authTokensUrlReady: true, endpointPathUrlReady: false },
@@ -760,11 +749,13 @@ describe('DatasetDownload form tests', () => {
 
   it('displays an error when Globus Transfer returns unhandled status code', async () => {
     server.use(
-      rest.post(apiRoutes.globusTransfer.path, (_req, res, ctx) =>
-        res(ctx.status(207), ctx.json({ status: 500, successes: [], failures: [] })),
-      ),
+      http.post(apiRoutes.globusTransfer.path, () => {
+        return HttpResponse.json(
+          { status: 500, successes: [], failures: [] },
+          { status: 207 }
+        );
+      }),
     );
-
     await initializeComponentForTest();
 
     // Click Transfer button
@@ -787,15 +778,18 @@ describe('DatasetDownload form tests', () => {
         ),
       { timeout: 5000 },
     );
+
   });
 
   it('shows a warning message when Globus transfer response has no data in successes or failures', async () => {
     server.use(
-      rest.post(apiRoutes.globusTransfer.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ status: 200, successes: [], failures: [] })),
-      ),
+      http.post(apiRoutes.globusTransfer.path, () => {
+        return HttpResponse.json(
+          { status: 200, successes: [], failures: [] },
+          { status: 200 }
+        );
+      }),
     );
-
     await initializeComponentForTest();
 
     // Click Transfer button
@@ -1066,7 +1060,9 @@ describe('DatasetDownload form tests', () => {
 
   it('Shows an alert when a collection search fails in the manage collections form', async () => {
     server.use(
-      rest.get(apiRoutes.globusSearchEndpoints.path, (_req, res, ctx) => res(ctx.status(500))),
+      http.get(apiRoutes.globusSearchEndpoints.path, () => {
+        return new HttpResponse(null, { status: 500 });
+      });
     );
 
     await initializeComponentForTest({
@@ -1289,11 +1285,10 @@ describe('DatasetDownload form tests', () => {
 
   it('handles empty results from endpoint search', async () => {
     server.use(
-      rest.get(apiRoutes.globusSearchEndpoints.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json([])),
-      ),
+      http.get(apiRoutes.globusSearchEndpoints.path, () => {
+        return HttpResponse.json([]);
+      }),
     );
-
     await initializeComponentForTest({
       ...defaultTestConfig,
       savedEndpoints: [],

--- a/frontend/src/components/Downloads/DownloadModal.test.tsx
+++ b/frontend/src/components/Downloads/DownloadModal.test.tsx
@@ -11,7 +11,8 @@ import {
   stacSearchResponseFixture,
   activeSearchQueryFixture,
 } from '../../test/mock/fixtures';
-import { rest, server } from '../../test/mock/server';
+import { http, server } from '../../test/mock/server';
+import { HttpResponse } from 'msw';
 import apiRoutes from '../../api/routes';
 import { clearStacCaches } from '../../api';
 
@@ -24,9 +25,9 @@ const mockActiveSearchQuery = activeSearchQueryFixture();
 // Helper function to mock STAC search responses
 const mockStacSearchResponse = (stacResults: StacSearchResponse) => {
   server.use(
-    rest.post(apiRoutes.esgfSearchSTAC.path, (_req, res, ctx) =>
-      res(ctx.status(200), ctx.json(stacResults)),
-    ),
+    http.post(apiRoutes.esgfSearchSTAC.path, () => {
+      return HttpResponse.json(stacResults);
+    }),
   );
 };
 
@@ -252,11 +253,10 @@ describe('DownloadModal component tests', () => {
   it('handles null stacResults gracefully', async () => {
     // Override STAC search to return empty results
     server.use(
-      rest.post(apiRoutes.esgfSearchSTAC.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ features: [], links: [], type: 'FeatureCollection' })),
-      ),
+      http.post(apiRoutes.esgfSearchSTAC.path, () => {
+        return HttpResponse.json({ type: 'FeatureCollection', features: [], links: [] });
+      }),
     );
-
     customRender(
       <DownloadModal
         show={true}
@@ -286,11 +286,10 @@ describe('DownloadModal component tests', () => {
     } as unknown as StacSearchResponse;
     // Override STAC search to return empty results
     server.use(
-      rest.post(apiRoutes.esgfSearchSTAC.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ features: [], links: [], type: 'FeatureCollection' })),
-      ),
+      http.post(apiRoutes.esgfSearchSTAC.path, () => {
+        return HttpResponse.json({ type: 'FeatureCollection', features: [], links: [] });
+      }),
     );
-
     customRender(
       <DownloadModal
         show={true}

--- a/frontend/src/components/Messaging/MessageCard.test.tsx
+++ b/frontend/src/components/Messaging/MessageCard.test.tsx
@@ -2,10 +2,15 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import MessageCard from './MessageCard';
 import customRender from '../../test/custom-render';
-import { rest, server } from '../../test/mock/server';
+import { http, server } from '../../test/mock/server';
+import { HttpResponse } from 'msw';
 
 it('renders message component with default markdown when file is wrong.', async () => {
-  server.use(rest.get('badFile.md', (_req, res, ctx) => res(ctx.status(404))));
+  server.use(
+    http.get('badFile.md', () => {
+      return new HttpResponse(null, { status: 404 });
+    })
+  );
   const consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   customRender(<MessageCard fileName="badFile.md" />);

--- a/frontend/src/components/Messaging/StartPopup.test.tsx
+++ b/frontend/src/components/Messaging/StartPopup.test.tsx
@@ -5,7 +5,8 @@ import { vi } from 'vitest';
 import StartPopup from './StartPopup';
 import StartupMessages from './messageDisplayData';
 import customRender from '../../test/custom-render';
-import { rest, server } from '../../test/mock/server';
+import { http, server } from '../../test/mock/server';
+import { HttpResponse } from 'msw';
 import { TourTitles } from '../../common/joyrideTutorials/reactJoyrideSteps';
 import { localStorageMock } from '../../test/mock/mockStorage';
 
@@ -100,8 +101,11 @@ describe('Start popup tests', () => {
   });
 
   it('renders start popup with wrong version specified', async () => {
-    server.use(rest.get('/changelog/v*.md', (_req, res, ctx) => res(ctx.body('Some changes'))));
-
+    server.use(
+      http.get('/changelog/v*.md', () => {
+        return new HttpResponse('Some changes');
+      }),
+    );
     localStorageMock.setItem('lastMessageSeen', 'test');
     customRender(<StartPopup />);
 

--- a/frontend/src/components/Search/Citation.test.tsx
+++ b/frontend/src/components/Search/Citation.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
-import { rest, server } from '../../test/mock/server';
+import { http, server } from '../../test/mock/server';
+import { HttpResponse } from 'msw';
 import apiRoutes from '../../api/routes';
 import Citation, { CitationInfo } from './Citation';
 import customRender from '../../test/custom-render';
@@ -47,7 +48,9 @@ describe('test Citation component', () => {
   it('renders Alert error fetching citation data ', async () => {
     server.use(
       // ESGF Citation API (uses dummy link)
-      rest.post(apiRoutes.citation.path, (_req, res, ctx) => res(ctx.status(404))),
+      http.post(apiRoutes.citation.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
     );
     customRender(<Citation url="citation_a" />);
 

--- a/frontend/src/components/Search/FilesTable.test.tsx
+++ b/frontend/src/components/Search/FilesTable.test.tsx
@@ -1,7 +1,8 @@
 import { within, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { rest, server } from '../../test/mock/server';
+import { http, server } from '../../test/mock/server';
+import { HttpResponse } from 'msw';
 import apiRoutes from '../../api/routes';
 import FilesTable, { DownloadUrls, genDownloadUrls, Props } from './FilesTable';
 import customRender from '../../test/custom-render';
@@ -104,7 +105,11 @@ describe('test FilesTable component', () => {
   });
 
   it('returns Alert when there is an error fetching files', async () => {
-    server.use(rest.get(apiRoutes.esgfSearch.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.get(apiRoutes.esgfSearch.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
 
     customRender(<FilesTable {...defaultProps} />);
     const alertMsg = await screen.findByRole('img', {
@@ -165,9 +170,9 @@ describe('test FilesTable component', () => {
       },
     };
     server.use(
-      rest.get(apiRoutes.esgfSearch.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json(response)),
-      ),
+      http.get(apiRoutes.esgfSearch.path, () => {
+        return HttpResponse.json(response);
+      })
     );
 
     customRender(
@@ -294,9 +299,9 @@ describe('test column sorting', () => {
 
   it('sorts by File Title column', async () => {
     server.use(
-      rest.get(apiRoutes.esgfSearch.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json(response)),
-      ),
+      http.get(apiRoutes.esgfSearch.path, () => {
+        return HttpResponse.json(response);
+      })
     );
     const colIdx = 1; // The column that File Title is in
     customRender(
@@ -343,9 +348,9 @@ describe('test column sorting', () => {
 
   it('sorts by Size column', async () => {
     server.use(
-      rest.get(apiRoutes.esgfSearch.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json(response)),
-      ),
+      http.get(apiRoutes.esgfSearch.path, () => {
+        return HttpResponse.json(response);
+      })
     );
     const colIdx = 2; // The column that Size is in
     customRender(
@@ -414,9 +419,9 @@ describe('test column sorting', () => {
     };
 
     server.use(
-      rest.get(apiRoutes.esgfSearch.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json(response)),
-      ),
+      http.get(apiRoutes.esgfSearch.path, () => {
+        return HttpResponse.json(response);
+      })
     );
     customRender(
       <FilesTable {...defaultProps} inputRecord={rawSearchResultFixture({ number_of_files: 2 })} />,

--- a/frontend/src/components/Search/Table.test.tsx
+++ b/frontend/src/components/Search/Table.test.tsx
@@ -3,7 +3,8 @@ import { vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { rawSearchResultFixture, rawSearchResultsFixture } from '../../test/mock/fixtures';
-import { rest, server } from '../../test/mock/server';
+import { http, server } from '../../test/mock/server';
+import { HttpResponse } from 'msw';
 import apiRoutes from '../../api/routes';
 import customRender from '../../test/custom-render';
 import Table, { Props } from './Table';
@@ -387,7 +388,11 @@ describe('test main table UI', () => {
   });
 
   it('displays an error when unable to access download via wget', async () => {
-    server.use(rest.post(apiRoutes.wget.path, (_req, res, ctx) => res(ctx.status(404))));
+    server.use(
+      http.post(apiRoutes.wget.path, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
 
     AtomWrapper.modifyAtomValue(AppStateKeys.userCart, [defaultProps.results[0]]);
     customRender(<Table {...defaultProps} />);

--- a/frontend/src/components/Search/index.test.tsx
+++ b/frontend/src/components/Search/index.test.tsx
@@ -9,7 +9,8 @@ import {
   stacSearchResultsFixture,
   stacAggregationsFixture,
 } from '../../test/mock/fixtures';
-import { rest, server } from '../../test/mock/server';
+import { http, server } from '../../test/mock/server';
+import { HttpResponse } from 'msw';
 import apiRoutes from '../../api/routes';
 import customRender from '../../test/custom-render';
 import { ActiveFacets, RawFacets, RawProject } from '../Facets/types';
@@ -69,8 +70,8 @@ describe('test Search component', () => {
     window.localStorage.setItem('searchResults', JSON.stringify(cachedData));
 
     server.use(
-      rest.get(apiRoutes.esgfSearch.path, async (_req, res) => {
-        return res.networkError('Failed to fetch');
+      http.get(apiRoutes.esgfSearch.path, () => {
+        return HttpResponse.error();
       }),
     );
 
@@ -178,9 +179,9 @@ describe('test Search component', () => {
     };
 
     server.use(
-      rest.get(apiRoutes.esgfSearch.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json(response)),
-      ),
+      http.get(apiRoutes.esgfSearch.path, () => {
+        return HttpResponse.json(response);
+      }),
     );
 
     customRender(<Search {...defaultProps} />);
@@ -674,12 +675,12 @@ describe('STAC project behavior', () => {
 
     // Mock STAC aggregations and STAC search endpoints
     server.use(
-      rest.post(apiRoutes.esgfAggregationsSTAC.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json(stacAggregationsFixture())),
-      ),
-      rest.post(apiRoutes.esgfSearchSTAC.path, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json(stacSearchResultsFixture().search)),
-      ),
+      http.post(apiRoutes.esgfAggregationsSTAC.path, () => {
+        return HttpResponse.json(stacAggregationsFixture());
+      }),
+      http.post(apiRoutes.esgfSearchSTAC.path, () => {
+        return HttpResponse.json(stacSearchResultsFixture().search);
+      }),
     );
 
     customRender(<Search {...defaultProps} />, { usesAtoms: true });

--- a/frontend/src/test/mock/server-handlers.ts
+++ b/frontend/src/test/mock/server-handlers.ts
@@ -4,7 +4,7 @@
  * The handlers can be overwritten in a test to mock behaviors such as a failed
  * HTTP response from an API (404).
  */
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import apiRoutes from '../../api/routes';
 import {
   ESGFSearchAPIFixture,
@@ -24,186 +24,194 @@ import {
 import { tempStorageGetMock, tempStorageSetMock } from './mockStorage';
 
 const handlers = [
-  rest.post(apiRoutes.keycloakAuth.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json(userAuthFixture())),
-  ),
-  rest.get(apiRoutes.globusAuth.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json(userAuthFixture())),
-  ),
-  rest.get(apiRoutes.globusResetTokens.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json({ status: 'success', message: 'Tokens reset successfully.' })),
-  ),
-  rest.get(apiRoutes.globusSearchEndpoints.path, async (_req, res, ctx) => {
-    // For testing multiple search results
-    const data = new URLSearchParams(_req.url.search);
+  http.post(apiRoutes.keycloakAuth.path, () => {
+    return HttpResponse.json(userAuthFixture());
+  }),
 
-    const searchText = data.get('search_text')?.toLowerCase();
+  http.get(apiRoutes.globusAuth.path, () => {
+    return HttpResponse.json(userAuthFixture());
+  }),
 
-    // Depending on search text, give back results
+  http.get(apiRoutes.globusResetTokens.path, () => {
+    return HttpResponse.json({ status: 'success', message: 'Tokens reset successfully.' });
+  }),
+
+  http.get(apiRoutes.globusSearchEndpoints.path, ({ request }) => {
+    const url = new URL(request.url);
+    const searchText = url.searchParams.get('search_text')?.toLowerCase();
+
     switch (searchText) {
       case null:
-        return res(ctx.status(200), ctx.json([]));
+        return HttpResponse.json([]);
       case 'lc public':
-        return res(ctx.status(200), ctx.json([globusEndpointFixture()]));
+        return HttpResponse.json([globusEndpointFixture()]);
       case 'multiple endpoints':
-        return res(
-          ctx.status(200),
-          ctx.json([
-            globusEndpointFixture({
-              canonical_name: 'endpoint1',
-              display_name: 'Endpoint 1',
-              entity_type: 'GCSv5_mapped_collection',
-              id: 'id1234567',
-              owner_id: 'ownerId123',
-              subscription_id: 'subscriptId123',
-            }),
-            globusEndpointFixture({
-              canonical_name: 'endpoint2',
-              display_name: 'Endpoint 2',
-              entity_type: 'GCSv5_endpoint',
-              id: 'id2345678',
-              owner_id: 'ownerId234',
-              subscription_id: 'subscriptId234',
-              path: 'path2',
-            }),
-            globusEndpointFixture({
-              canonical_name: 'endpoint3',
-              display_name: 'Endpoint 3',
-              entity_type: 'unknown',
-              id: 'id1234567',
-              owner_id: 'ownerId123',
-              subscription_id: '',
-            }),
-          ]),
-        );
+        return HttpResponse.json([
+	  globusEndpointFixture({
+	    canonical_name: 'endpoint1',
+	    display_name: 'Endpoint 1',
+	    entity_type: 'GCSv5_mapped_collection',
+	    id: 'id1234567',
+	    owner_id: 'ownerId123',
+	    subscription_id: 'subscriptId123',
+	  }),
+	  globusEndpointFixture({
+	    canonical_name: 'endpoint2',
+	    display_name: 'Endpoint 2',
+	    entity_type: 'GCSv5_endpoint',
+	    id: 'id2345678',
+	    owner_id: 'ownerId234',
+	    subscription_id: 'subscriptId234',
+	    path: 'path2',
+	  }),
+	  globusEndpointFixture({
+	    canonical_name: 'endpoint3',
+	    display_name: 'Endpoint 3',
+	    entity_type: 'unknown',
+	    id: 'id1234567',
+	    owner_id: 'ownerId123',
+	    subscription_id: '',
+	  }),
+        ]);
       case 'error404':
-        return res(ctx.status(404), ctx.json({ error: 'search error.' }));
+        return HttpResponse.json({ error: 'search error.' }, { status: 404 });
       default:
-        return res(ctx.status(200), ctx.json([]));
+        return HttpResponse.json([]);
     }
   }),
-  rest.post(apiRoutes.globusTransfer.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json(globusTransferResponseFixture())),
-  ),
-  rest.get(apiRoutes.userInfo.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json(userInfoFixture())),
-  ),
-  rest.post(apiRoutes.tempStorageGet.path, async (_req, res, ctx) => {
-    const data = _req.body as { dataKey: string; dataValue: unknown };
+
+  http.post(apiRoutes.globusTransfer.path, () => {
+    return HttpResponse.json(globusTransferResponseFixture());
+  }),
+
+  http.get(apiRoutes.userInfo.path, () => {
+    return HttpResponse.json(userInfoFixture());
+  }),
+
+  http.post(apiRoutes.tempStorageGet.path, async ({ request }) => {
+    const data = (await request.json()) as { dataKey: string; dataValue: unknown };
     if (data && data.dataKey) {
       const keyName = data.dataKey;
-
       const value: unknown = tempStorageGetMock(keyName);
-      return res(ctx.status(200), ctx.json({ [keyName]: value }));
+      return HttpResponse.json({ [keyName]: value });
     }
-    return res(ctx.status(400), ctx.json('Load failed!'));
+    return new HttpResponse('Load failed!', { status: 400 });
   }),
-  rest.post(apiRoutes.tempStorageSet.path, async (_req, res, ctx) => {
-    const reqBody = _req.body as string;
-    const data = JSON.parse(reqBody) as { dataKey: string; dataValue: unknown };
-    if (data && data.dataKey && data.dataValue) {
-      const keyName = data.dataKey;
 
-      tempStorageSetMock(keyName, data.dataValue as string);
-      return res(ctx.status(200), ctx.json({ data: 'Save success!' }));
+  http.post(apiRoutes.tempStorageSet.path, async ({ request }) => {
+    // Note: If you were previously sending a raw string and parsing it, 
+    // request.json() is preferred if the client sends application/json.
+    try {
+      const data = (await request.json()) as { dataKey: string; dataValue: unknown };
+      if (data && data.dataKey && data.dataValue) {
+        tempStorageSetMock(data.dataKey, data.dataValue as string);
+        return HttpResponse.json({ data: 'Save success!' });
+      }
+    } catch (e) {
+      // Fallback or error handling for invalid JSON
     }
-    return res(ctx.status(400), ctx.json({ data: 'Save failed!' }));
+    return HttpResponse.json({ data: 'Save failed!' }, { status: 400 });
   }),
-  rest.get(apiRoutes.userInfo.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json(userInfoFixture())),
-  ),
-  rest.get(apiRoutes.userCart.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json(rawUserCartFixture())),
-  ),
-  rest.patch(apiRoutes.userCart.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json(rawUserCartFixture())),
-  ),
-  rest.get(apiRoutes.userSearches.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json({ results: userSearchQueriesFixture() })),
-  ),
-  rest.post(apiRoutes.userSearches.path, async (_req, res, ctx) =>
-    res(ctx.status(201), ctx.json(userSearchQueryFixture())),
-  ),
-  rest.delete(apiRoutes.userSearch.path, async (_req, res, ctx) => res(ctx.status(204))),
-  rest.get(apiRoutes.projects.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json({ results: projectsFixture() })),
-  ),
-  rest.get(apiRoutes.esgfSearch.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json(ESGFSearchAPIFixture())),
-  ),
-  rest.post(apiRoutes.citation.path, async (_req, res, ctx) => {
-    // For testing more than one set of creators
-    const data = _req.body as { [key: string]: unknown };
+
+  http.get(apiRoutes.userCart.path, () => {
+    return HttpResponse.json(rawUserCartFixture());
+  }),
+
+  http.patch(apiRoutes.userCart.path, () => {
+    return HttpResponse.json(rawUserCartFixture());
+  }),
+
+  http.get(apiRoutes.userSearches.path, () => {
+    return HttpResponse.json({ results: userSearchQueriesFixture() });
+  }),
+
+  http.post(apiRoutes.userSearches.path, () => {
+    return HttpResponse.json(userSearchQueryFixture(), { status: 201 });
+  }),
+
+  http.delete(apiRoutes.userSearch.path, () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.get(apiRoutes.projects.path, () => {
+    return HttpResponse.json({ results: projectsFixture() });
+  }),
+
+  http.get(apiRoutes.esgfSearch.path, () => {
+    return HttpResponse.json(ESGFSearchAPIFixture());
+  }),
+
+  http.post(apiRoutes.citation.path, async ({ request }) => {
+    const data = (await request.json()) as { [key: string]: unknown };
     if (data && data.citurl) {
       const citationUrl = data.citurl;
       if (citationUrl === 'citation_a') {
-        return res(
-          ctx.status(200),
-          ctx.json(
-            rawCitationFixture({
-              creators: [
-                { creatorName: 'Bobby' },
-                { creatorName: 'Tommy' },
-                { creatorName: 'Joey' },
-              ],
-            }),
-          ),
+        return HttpResponse.json(
+          rawCitationFixture({
+            creators: [
+              { creatorName: 'Bobby' },
+              { creatorName: 'Tommy' },
+              { creatorName: 'Joey' },
+            ],
+          })
         );
       }
       /* istanbul ignore next -- @preserve */
       if (citationUrl === 'citation_b') {
-        return res(
-          ctx.status(200),
-          ctx.json(
-            rawCitationFixture({
-              creators: [
-                { creatorName: 'Bobby' },
-                { creatorName: 'Tommy' },
-                { creatorName: 'Timmy' },
-                { creatorName: 'Joey' },
-              ],
-            }),
-          ),
+        return HttpResponse.json(
+          rawCitationFixture({
+            creators: [
+              { creatorName: 'Bobby' },
+              { creatorName: 'Tommy' },
+              { creatorName: 'Timmy' },
+              { creatorName: 'Joey' },
+            ],
+          })
         );
       }
     }
+    return HttpResponse.json(rawCitationFixture());
+  }),
 
-    return res(ctx.status(200), ctx.json(rawCitationFixture()));
+  http.post(apiRoutes.wget.path, () => {
+    return new HttpResponse(null, { status: 200 });
   }),
-  rest.post(apiRoutes.wget.path, async (_req, res, ctx) => res(ctx.status(200))),
-  rest.get(apiRoutes.nodeStatus.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json(rawNodeStatusFixture())),
-  ),
-  rest.get(apiRoutes.introMarkdown.path, async (_req, res, ctx) =>
-    res(ctx.status(200), ctx.body('Some Markdown')),
-  ),
-  rest.get(apiRoutes.esgfSearchSTAC.path, async (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(stacSearchResultsFixture()));
+
+  http.get(apiRoutes.nodeStatus.path, () => {
+    return HttpResponse.json(rawNodeStatusFixture());
   }),
-  rest.post(apiRoutes.esgfSearchSTAC.path, async (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(stacSearchResultsFixture().search));
+
+  http.get(apiRoutes.introMarkdown.path, () => {
+    return new HttpResponse('Some Markdown', {
+      headers: { 'Content-Type': 'text/markdown' },
+    });
   }),
-  rest.get(apiRoutes.esgfAggregationsSTAC.path, async (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(stacAggregationsFixture()));
+
+  http.get(apiRoutes.esgfSearchSTAC.path, () => {
+    return HttpResponse.json(stacSearchResultsFixture());
   }),
-  rest.post(apiRoutes.esgfAggregationsSTAC.path, async (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(stacAggregationsFixture()));
+
+  http.post(apiRoutes.esgfSearchSTAC.path, () => {
+    return HttpResponse.json(stacSearchResultsFixture().search);
   }),
-  rest.get('/projects/projects.json', async (_req, res, ctx) => {
+
+  http.get(apiRoutes.esgfAggregationsSTAC.path, () => {
+    return HttpResponse.json(stacAggregationsFixture());
+  }),
+
+  http.post(apiRoutes.esgfAggregationsSTAC.path, () => {
+    return HttpResponse.json(stacAggregationsFixture());
+  }),
+
+  http.get('/projects/projects.json', () => {
     // Return a valid empty config (tests will use default projects)
-    return res(
-      ctx.status(200),
-      ctx.json({
-        additionalProjects: [],
-        whitelist: [],
-        blacklist: [],
-      }),
-    );
+    return HttpResponse.json({ additionalProjects: [], whitelist: [], blacklist: [], });
   }),
+
   // Default fallback handler
-  rest.get('*', async (req, res, ctx) => {
+  http.get('*', () => {
     // console.error(`Please add request handler for ${req.url.toString()}`);
-    return res(ctx.status(500), ctx.json({ error: 'You must add request handler.' }));
+    return HttpResponse.json({ error: 'You must add request handler.' }, { status: 500 });
   }),
 ];
 

--- a/frontend/src/test/mock/server.ts
+++ b/frontend/src/test/mock/server.ts
@@ -5,9 +5,9 @@
  * handle it as if it were a real server.
  * https://kentcdodds.com/blog/stop-mocking-fetch
  */
-import { rest } from 'msw';
+import { http } from 'msw';
 import { setupServer } from 'msw/node';
 import handlers from './server-handlers';
 
 const server = setupServer(...handlers);
-export { server, rest };
+export { server, http };


### PR DESCRIPTION
## Description

Closes #938 by applying the necessary conversions between 'msw' v1 and v2, specifically, version 2.13.5. 

## Type of change

The 'msw' v1 to v2 upgrade is considered a 'breaking' change, therefore, v1 functionalities/syntax would no longer work.

## How Has This Been Tested?

I have not yet deployed metagrid to our node, so I cannot really test the changes myself.